### PR TITLE
Agrear gitIgnore y capturar selectores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Node.js
+node_modules/
+
+# Build output
+dist/
+build/
+
+# Environment variables
+.env
+
+# IDE files
+.vscode/
+.idea/
+
+# Logs
+logs/
+*.log
+
+# Dependency lock files
+package-lock.json
+yarn.lock

--- a/cypress/e2e/prueba.cy.js
+++ b/cypress/e2e/prueba.cy.js
@@ -26,7 +26,7 @@ describe('template spec', () => {
         const divText = Cypress.$($el).text().trim();
         if (divText === 'Consultar') {
           console.log('Encontrado: ', divText);
-          cy.wrap($el).click({force: true});
+          cy.wrap($el).click({ force: true });
         }
 
       });
@@ -40,7 +40,7 @@ describe('template spec', () => {
         const divText = Cypress.$($el).text().trim();
         if (divText === 'Desarrollo Coexistencia (SF-PYT)') {
           // console.log('Encontrado: ', divText);
-          cy.wrap($el).click({force: true});
+          cy.wrap($el).click({ force: true });
         }
 
       });
@@ -54,69 +54,83 @@ describe('template spec', () => {
         $el.find('td').each((index, td) => {
           const $td = Cypress.$(td);
           const tdText = $td.text().trim();
-  
+
           if (tdText === 'Desarrollos varios') {
             // console.log('Encontrado td: ', tdText);
             count++;
           }
         }
         );
-        if(count == 1){
-        $el.find('td').each((index, td) => {
-          const $td = Cypress.$(td);
+        if (count == 1) {
+          $el.find('td').each((index, td) => {
+            const $td = Cypress.$(td);
 
-           $td.find('a').each((index, a)=>{
-            const $a = Cypress.$(a);
-            $a.find('img').each((index, img) => {
-              const $img = Cypress.$(img);
-              const altText = $img.attr('alt');
+            $td.find('a').each((index, a) => {
+              const $a = Cypress.$(a);
+              $a.find('img').each((index, img) => {
+                const $img = Cypress.$(img);
+                const altText = $img.attr('alt');
 
-              if (altText === 'Nueva Transacción') {
-                // console.log('Encontrado img con alt "Nueva Transacción"');
-                cy.wrap($a).dblclick({force: true});
-              }
-              
+                if (altText === 'Nueva Transacción') {
+                  // console.log('Encontrado img con alt "Nueva Transacción"');
+                  cy.wrap($a).dblclick({ force: true });
+                }
+
               })
             })
-            
-            })
-          }
+
+          })
         }
+      }
       );
 
-      });
-     
-      cy.wait(1000);
-      cy.get('frame').then(($frame) => {
-  
-        const doc = $frame.contents();
-        const selector1 = doc.find('select');
-        
-        selector1.each((selector) => {
-          console.log(selector);
-          const $selector = Cypress.$(selector);
-          const id = $selector.attr('name');
-          const id2 = selector1.attr('name');
-          const id3 = selector.attr('name');
-          console.log('selector id ', id , id2);
+    });
 
-          if('id_categoria' === id) {
-            cy.wrap(selector).select('Desarrollo');
-            console.log('seleccione en id_categoria, Desarrollo');
+    cy.wait(1000);
+    cy.get('frame').then(($frame) => {
+
+      const doc = $frame.contents();
+      const selector1 = doc.find('select');
+      console.log("selector1", selector1);
+
+      for (const key in selector1) {
+        if (Object.hasOwnProperty.call(selector1, key)) {
+          const element = selector1[key];
+          const $selector = Cypress.$(element);
+
+          if (element.name === 'id_categoria') {
+            console.log('====================================');
+            console.log('element', element);
+            cy.wrap($selector).select('Desarrollo');
+            console.log('====================================');
           }
-  
-          if('cod_tipotransaccion' == id){
-            selector.select('PUB/NE - 16-Investigación'); //variable
-            console.log('seleccione en cod_tipotransaccion, Desarrollo');
-          }
+        }
+      }
+      // selector1.each((selector) => {D
+      //   console.log(selector);
+      //   const $selector = Cypress.$(selector);
+      //   const id = $selector.attr('name');
+      //   const id2 = selector1.attr('name');
+      //   // const id3 = selector.attr('name');
+      //   console.log('selector id ', id, id2);
 
-        });
+      //   if ('id_categoria' === id) {
+      //     cy.wrap(selector).select('Desarrollo');
+      //     console.log('seleccione en id_categoria, Desarrollo');
+      //   }
+
+      //   if ('cod_tipotransaccion' == id) {
+      //     selector.select('PUB/NE - 16-Investigación'); //variable
+      //     console.log('seleccione en cod_tipotransaccion, Desarrollo');
+      //   }
+
+      // });
 
 
-        
 
-      });
-    
-    
-    });    
-  })
+
+    });
+
+
+  });
+})


### PR DESCRIPTION
Se agrega gitignore para excluir `node_modules` y se capturan los selectores para setear los select en pantalla.